### PR TITLE
feat: use `winborder` for interactive prompt if is set

### DIFF
--- a/lua/code-bridge/init.lua
+++ b/lua/code-bridge/init.lua
@@ -301,7 +301,7 @@ local function create_prompt_input(initial_content, callback)
       row = row,
       col = col,
       style = 'minimal',
-      border = 'rounded',
+      border = vim.o.winborder ~= '' and vim.o.winborder or 'rounded',
       title = ' Edit Prompt ',
       title_pos = 'center',
     })


### PR DESCRIPTION
## Description
First of all, thank you for creating such a wonderful plugin! The minimal and seamless integration between Neovim and Claude Code is absolutely fantastic. It's been incredibly helpful in my workflow.

##  Change
Updated the floating prompt window's `border` option to respect the user's global winborder preference if is set. This change is completely backward compatible