### PR TITLE
 Add support for matching multiple tmux process names

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ The plugin works out of the box with no configuration required, with the followi
   tmux = {
     target_mode = 'window_name', -- 'window_name', 'current_window', 'find_process'
     window_name = 'claude',      -- window name to search for when target_mode = 'window_name'
-    process_name = 'claude',     -- string or list of process names to search for when target_mode = 'current_window' or 'find_process'
+    process_name = 'claude',     -- process name(s) to search for when target_mode = 'current_window' or 'find_process'
     switch_to_target = true,     -- whether to switch to the target after sending
     find_node_process = false,   -- whether to look for node processes with matching name
   },
@@ -283,7 +283,7 @@ require('code-bridge').setup({
 require('code-bridge').setup({
   tmux = {
     target_mode = 'current_window',
-    process_name = { 'claude', 'node' }, -- match multiple process names
+    process_name = 'claude',
     switch_to_target = false,  -- don't switch to claude pane after sending
     find_node_process = true, -- agent runs inside node.js process
   }
@@ -300,6 +300,8 @@ require('code-bridge').setup({
   }
 })
 ```
+
+Multiple process names may also be configured to target different agents by providing a list. e.g. `process_name = { 'claude', 'opencode' }`.
 
 ## Example Workflows
 

--- a/doc/code-bridge.txt
+++ b/doc/code-bridge.txt
@@ -269,6 +269,9 @@ window >
     })
 <
 
+Multiple process names may also be configured to target different agents by
+providing a list. e.g. `process_name = { 'claude', 'opencode' }`.
+
 Optional key bindings: >
     -- Basic tmux commands
     vim.keymap.set("n", "<leader>ct", ":CodeBridgeTmux<CR>", 

--- a/lua/code-bridge/init.lua
+++ b/lua/code-bridge/init.lua
@@ -6,7 +6,7 @@ local config = {
   tmux = {
     target_mode = 'window_name', -- 'window_name', 'current_window', 'find_process'
     window_name = 'claude',      -- window name to search for when target_mode = 'window_name'
-    process_name = 'claude',     -- string or list of process names to search for when target_mode = 'current_window' or 'find_process'
+    process_name = 'claude',     -- process name(s) to search for when target_mode = 'current_window' or 'find_process'
     switch_to_target = true,     -- whether to switch to the target after sending
     find_node_process = false,   -- whether to look for node processes with matching name
   },
@@ -770,7 +770,7 @@ M.claude_query = function(opts)
   local primary_process_name = get_process_names()[1] or config.tmux.process_name or 'claude'
   local cmd_args = { primary_process_name }
 
-  local is_opencode = vim.tbl_contains(get_process_names(), 'opencode')
+  local is_opencode = primary_process_name == 'opencode'
 
   if is_reuse then
     table.insert(cmd_args, "-c")


### PR DESCRIPTION
 Allow matching multiple tmux process names for targets

  - let tmux.process_name accept a string or list, normalizing and
    matching any of them when finding panes/processes
  - adjust error messaging and opencode detection to reflect multiple
    process names, using first configured name as default command arg
  - update README and vim docs with new configuration and example for
    multiple process names