### PR TITLE
docs: update minimum Neovim version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ easily write detailed prompts.
 
 ## Requirements
 
-- Neovim 0.7+
+- Neovim 0.11+
 - Claude Code or Opencode installed and configured
 - tmux (optional)
 

--- a/doc/code-bridge.txt
+++ b/doc/code-bridge.txt
@@ -24,7 +24,7 @@ buffers.
 ==============================================================================
 REQUIREMENTS                                          *code-bridge-requirements*
 
-- Neovim 0.7+
+- Neovim 0.11+
 - Claude Code or Opencode installed and configured
 - tmux (optional)
 


### PR DESCRIPTION
## Summary

  Update the documented minimum Neovim version from 0.7+ to 0.11+.

  The plugin currently uses APIs that are not available in Neovim 0.7:

  - `vim.system()` is used by `CodeBridgeQuery` / `CodeBridgeChat` and was added in Neovim 0.10.
  - `vim.o.winborder` is used by the interactive prompt floating window and was added in Neovim 0.11.

  Because of this, the previous `Neovim 0.7+` requirement could lead users on older versions to install the plugin successfully but hit runtime errors when using chat or interactive prompt features.

  ## Changes

  - Update README requirement from `Neovim 0.7+` to `Neovim 0.11+`.
  - Update help documentation requirement to match README.